### PR TITLE
chore: automate versioning and changelog formatting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,5 @@ jobs:
           GITHUB_TOKEN: '${{ steps.get_token.outputs.token }}'
         with:
           commitMode: 'github-api'
-          publish: 'pnpm changeset publish'
-          version: 'pnpm changeset version && pnpm -w reformat-changelogs'
+          version: 'version'
           commit: '🦋 Version Packages'

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "prepare": "node .husky/install.js",
     "postinstall": "turbo @repo/configs#build",
     "renovate:validate": "npx --yes --package renovate -- renovate-config-validator",
+    "version": "pnpm changeset version && pnpm reformat-changelogs",
     "reformat-changelogs": "pnpm -F @repo/scripts reformat-changelogs",
     "renovate-add-changese": "pnpm -F @repo/scripts renovate-add-changese"
   },


### PR DESCRIPTION
Add a new npm script "version" that runs changeset versioning
and reformats changelogs to ensure consistency. Update the
release workflow to use this new script for versioning instead
of separate commands. This streamlines the release process and
reduces manual steps.