### PR TITLE
ci: update release workflow to use pnpm commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,5 +38,6 @@ jobs:
           GITHUB_TOKEN: '${{ steps.get_token.outputs.token }}'
         with:
           commitMode: 'github-api'
-          version: 'version'
+          publish: 'pnpm changeset publish'
+          version: 'pnpm version'
           commit: '🦋 Version Packages'


### PR DESCRIPTION
Modify release.yml to replace static version command with pnpm
commands for publishing and versioning packages. This change ensures
the release process uses pnpm for consistent package management and
automates publishing during the release workflow.