### PR TITLE
feat: allow manual triggering of release workflow

### DIFF
--- a/.changeset/tidy-carrots-wish.md
+++ b/.changeset/tidy-carrots-wish.md
@@ -1,0 +1,5 @@
+---
+"@repo/changelog": minor
+---
+
+Allow manually triggering the release workflow

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ permissions:
   pull-requests: write
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master


### PR DESCRIPTION
Add workflow_dispatch event to the release GitHub Actions workflow to
enable manual triggering. This change improves release flexibility by
allowing releases to be initiated on demand, not just on pushes to master.