### PR TITLE
fix(ci): update release workflow to run version script

### DIFF
--- a/.changeset/deep-feet-allow.md
+++ b/.changeset/deep-feet-allow.md
@@ -1,0 +1,5 @@
+---
+"@repo/changelog": patch
+---
+
+Use `pnpm run` to actually run the version script

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,5 +40,5 @@ jobs:
         with:
           commitMode: 'github-api'
           publish: 'pnpm changeset publish'
-          version: 'pnpm version'
+          version: 'pnpm run version'
           commit: '🦋 Version Packages'


### PR DESCRIPTION
Change the release workflow to use `pnpm run version` instead of
`pnpm version` to correctly execute the version script. This ensures
the versioning step runs as intended during the release process.