### PR TITLE
ci: run verify workflow on pull_request and merge_group

### DIFF
--- a/.changeset/fair-peas-tan.md
+++ b/.changeset/fair-peas-tan.md
@@ -1,0 +1,5 @@
+---
+"@repo/changelog": minor
+---
+
+Run verify workflow on events `pull-request` and `merge_group` to enable merge trains

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,9 +1,9 @@
 name: Verify
 
 on:
-  push:
-    branches-ignore:
-      - master
+  pull_request:
+  merge_group:
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Update verify workflow triggers to run on pull_request and merge_group
events instead of push. This change enables merge trains by ensuring
verification runs during pull request and merge group events, improving
CI integration and code quality checks before merging.