### PR TITLE
feat(scripts): detect and group changeset generated deps updates

### DIFF
--- a/.changeset/six-mammals-smoke.md
+++ b/.changeset/six-mammals-smoke.md
@@ -1,0 +1,5 @@
+---
+"@repo/scripts": minor
+---
+
+Detect changeset generated `Updated dependencies` entries and move them to the dependencies section as well.

--- a/packages/scripts/src/reformat-changelogs/__snapshots__/full.example.md
+++ b/packages/scripts/src/reformat-changelogs/__snapshots__/full.example.md
@@ -97,6 +97,17 @@
 - eddbb5d: deps: Updated lockfile
 - 1b989b0: deps: Updated lockfile
 - 8b575a9: Fix package url. This should display changelogs in renovate.
+- Updated dependencies [12cc633]
+- Updated dependencies [12cc633]
+- Updated dependencies [12cc633]
+- Updated dependencies [12cc633]
+- Updated dependencies [22b1bd4]
+- Updated dependencies [8987763]
+- Updated dependencies [fc0ecc1]
+- Updated dependencies [d53be68]
+- Updated dependencies [81b22c8]
+  - @desselbane/ts-helpers@3.0.0
+
 
 ## 2.0.0-next.7
 

--- a/packages/scripts/src/reformat-changelogs/__snapshots__/full.snap.md
+++ b/packages/scripts/src/reformat-changelogs/__snapshots__/full.snap.md
@@ -83,6 +83,7 @@
 
 - 8b575a9: Fix package url. This should display changelogs in renovate.
 
+
 ### Dependency Changes
 
 <details>
@@ -103,6 +104,13 @@
 - ea663cf: deps: Updated lockfile
 - eddbb5d: deps: Updated lockfile
 - 1b989b0: deps: Updated lockfile
+- Updated dependencies [12cc633]
+- Updated dependencies [22b1bd4]
+- Updated dependencies [8987763]
+- Updated dependencies [fc0ecc1]
+- Updated dependencies [d53be68]
+- Updated dependencies [81b22c8]
+  - @desselbane/ts-helpers@3.0.0
 
 
 </details>

--- a/packages/scripts/src/reformat-changelogs/__snapshots__/generated-duplicates.example.md
+++ b/packages/scripts/src/reformat-changelogs/__snapshots__/generated-duplicates.example.md
@@ -1,0 +1,10 @@
+# foo
+
+## 1.0.0
+
+### Patch Changes
+
+- Updated dependencies [12cc633]
+- Updated dependencies [12cc633]
+- Updated dependencies [12cc633]
+- Updated dependencies [12cc633]

--- a/packages/scripts/src/reformat-changelogs/__snapshots__/generated-duplicates.snap.md
+++ b/packages/scripts/src/reformat-changelogs/__snapshots__/generated-duplicates.snap.md
@@ -1,0 +1,13 @@
+# foo
+
+## 1.0.0
+
+### Dependency Changes
+
+<details>
+<summary> Click to expand </summary>
+
+- Updated dependencies [12cc633]
+
+
+</details>

--- a/packages/scripts/src/reformat-changelogs/__snapshots__/generated.example.md
+++ b/packages/scripts/src/reformat-changelogs/__snapshots__/generated.example.md
@@ -1,0 +1,15 @@
+# foo
+
+## 1.0.0
+
+### Patch Changes
+
+- Updated dependencies [12cc633]
+- Updated dependencies [22b1bd4]
+- Updated dependencies [8987763]
+- Updated dependencies [d53be68]
+  - @desselbane/ts-helpers@3.0.0
+  - @desselbane/composables@2.0.0
+- Updated dependencies [81b22c8]
+  - @desselbane/ts-helpers@3.0.0
+- Updated dependencies [fc0ecc1]

--- a/packages/scripts/src/reformat-changelogs/__snapshots__/generated.snap.md
+++ b/packages/scripts/src/reformat-changelogs/__snapshots__/generated.snap.md
@@ -1,0 +1,21 @@
+# foo
+
+## 1.0.0
+
+### Dependency Changes
+
+<details>
+<summary> Click to expand </summary>
+
+- Updated dependencies [12cc633]
+- Updated dependencies [22b1bd4]
+- Updated dependencies [8987763]
+- Updated dependencies [d53be68]
+  - @desselbane/ts-helpers@3.0.0
+  - @desselbane/composables@2.0.0
+- Updated dependencies [81b22c8]
+  - @desselbane/ts-helpers@3.0.0
+- Updated dependencies [fc0ecc1]
+
+
+</details>

--- a/packages/scripts/src/reformat-changelogs/reformat-changelogs.l1.spec.ts
+++ b/packages/scripts/src/reformat-changelogs/reformat-changelogs.l1.spec.ts
@@ -38,6 +38,12 @@ const removeEmptyChangelog = actualReadFileSync(
 const noDuplicateChangelog = actualReadFileSync(
   path.join(snapshotFolder, 'no-duplicate.example.md'),
 )
+const generatedChangelog = actualReadFileSync(
+  path.join(snapshotFolder, 'generated.example.md'),
+)
+const generatedDuplicatesChangelog = actualReadFileSync(
+  path.join(snapshotFolder, 'generated-duplicates.example.md'),
+)
 
 const changelogPath = path.join('changelog', 'CHANGELOG.md')
 const changelogFullPath = path.join(workspaceRoot, changelogPath)
@@ -169,5 +175,31 @@ describe('reformat-changelogs', () => {
     assertNotNil(secondContent)
 
     expect(secondContent).toBe(newContent)
+  })
+
+  it('should add generated dependency updates from changesets', async () => {
+    readFileSync.mockReturnValue(generatedChangelog)
+
+    run()
+
+    const newContent = writeFileSync.mock.lastCall?.[1]
+
+    assertNotNil(newContent)
+    await expect(newContent).toMatchFileSnapshot(
+      path.join(snapshotFolder, 'generated.snap.md'),
+    )
+  })
+
+  it('should deduplicate generated dependency updates from changesets', async () => {
+    readFileSync.mockReturnValue(generatedDuplicatesChangelog)
+
+    run()
+
+    const newContent = writeFileSync.mock.lastCall?.[1]
+
+    assertNotNil(newContent)
+    await expect(newContent).toMatchFileSnapshot(
+      path.join(snapshotFolder, 'generated-duplicates.snap.md'),
+    )
   })
 })


### PR DESCRIPTION
Add support to identify "Updated dependencies" entries generated by
changesets and move them into a dedicated dependency changes section in
changelogs. This improves clarity by separating dependency updates from
other patch changes.

Also implement deduplication of these generated dependency updates to
avoid repeated entries. Add tests and snapshots to verify correct
parsing, grouping, and deduplication behavior.