### PR TITLE
feat: allow setting log level for manual renovate runs

### DIFF
--- a/.changeset/beige-aliens-lick.md
+++ b/.changeset/beige-aliens-lick.md
@@ -1,0 +1,5 @@
+---
+"@repo/changelog": minor
+---
+
+Allow setting the log level for manual renovate dispatches

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,6 +1,18 @@
 name: Renovate
 on:
   workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Which log level renovate should use see https://docs.renovatebot.com/troubleshooting/#log-debug-levels'
+        default: 'INFO'
+        required: true
+        type: choice
+        options:
+          - DEBUG
+          - INFO
+          - WARN
+          - ERROR
+          - FATAL
   schedule:
     # Run every 4h
     - cron: '0 */4 * * *'
@@ -29,6 +41,8 @@ jobs:
 
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@v43.0.2
+        env:
+          LOG_LEVEL: ${{ inputs.logLevel || 'INFO' }}
         with:
           configurationFile: .github/renovate-global-config.json5
           token: '${{ steps.get_token.outputs.token }}'


### PR DESCRIPTION
Add a logLevel input to the renovate workflow_dispatch event to enable
specifying the log level when manually triggering Renovate. Pass the
selected log level as an environment variable to the Renovate GitHub
Action. This improves debugging and monitoring by allowing more control
over log verbosity during manual runs.