### PR TITLE
✨ fix: use npm run instead of pnpm for renovate changeset

### DIFF
--- a/.changeset/good-kings-grin.md
+++ b/.changeset/good-kings-grin.md
@@ -1,0 +1,5 @@
+---
+"@repo/changelog": patch
+---
+
+Use `npm run` instead of `pnpm -w` to run the `renovate-add-changeset` command during dependency upgrades. This hopefully fixes the issue that pnpm is not available during upgrades of github-actions.

--- a/.github/renovate-global-config.json5
+++ b/.github/renovate-global-config.json5
@@ -1,4 +1,4 @@
 {
-  allowedCommands: ['^pnpm -w renovate-add-changeset.*'],
+  allowedCommands: ['^npm run renovate-add-changeset.*'],
   repositories: ['DesselBane/mono']
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,7 +32,7 @@
   },
   postUpgradeTasks: {
     commands: [
-      "pnpm -w renovate-add-changeset --currentVersion '{{currentVersion}}' --newVersion '{{newVersion}}' --depName '{{depName}}' --depType '{{depType}}' --packageFile '{{packageFile}}' --manager '{{manager}}' --updateType '{{updateType}}'",
+      "npm run renovate-add-changeset --currentVersion '{{currentVersion}}' --newVersion '{{newVersion}}' --depName '{{depName}}' --depType '{{depType}}' --packageFile '{{packageFile}}' --manager '{{manager}}' --updateType '{{updateType}}'",
     ],
     fileFilters: ['.changeset/*.md'],
     executionMode: 'update',


### PR DESCRIPTION
Switch the renovate post-upgrade command to use `npm run` instead of
`pnpm -w` to run the `renovate-add-chet` script. change fixes
issues where `pnpm` is not available during GitHub Actions dependency
upgrades, ensuring the changeset is added reliably. Also update allowed
commands in the global config accordingly.