### PR TITLE
✨ fix: prevent safeTry and safeTryAsync from throwing on null/undefined return

### DIFF
--- a/.changeset/mighty-sites-cheat.md
+++ b/.changeset/mighty-sites-cheat.md
@@ -1,0 +1,5 @@
+---
+"@desselbane/ts-helpers": patch
+---
+
+Fix `safeTry` and `safeTryAsync` do not throw if null or undefined is returned by the function.

--- a/packages/ts-helpers/src/safe-try/safe-try.ts
+++ b/packages/ts-helpers/src/safe-try/safe-try.ts
@@ -1,5 +1,3 @@
-import { assertNotNil } from '../assertions'
-
 type SafeReturn<TValue> =
   | (readonly [undefined, TValue] & {
       readonly data: TValue
@@ -31,8 +29,6 @@ function createSafeReturnValue<TValue>(
   value?: TValue,
 ): SafeReturn<TValue> {
   if (error === undefined) {
-    assertNotNil(value)
-
     const returnValue = [undefined, value] as IntermediateSafeReturn<TValue>
     returnValue.error = undefined
     returnValue.data = value


### PR DESCRIPTION
Remove wrong assertion in safeTry to allow functions that
return null or undefined without causing errors. This change fixes
an issue where safeTry and safeTryAsync would throw unexpectedly,
improving robustness when handling nullable return values.