### PR TITLE
add-vitest-eslint-plugin

### DIFF
--- a/.changeset/bright-adults-hug.md
+++ b/.changeset/bright-adults-hug.md
@@ -1,0 +1,5 @@
+---
+"@desselbane/configs": minor
+---
+
+Support and enable type tests by default. Any files using the `.d-spec.ts` extension will are classified as type tests.

--- a/.changeset/cruel-buckets-yawn.md
+++ b/.changeset/cruel-buckets-yawn.md
@@ -1,0 +1,5 @@
+---
+"@desselbane/configs": minor
+---
+
+Eslint `reportUnusedInlineConfigs` as errors

--- a/.changeset/fruity-baboons-joke.md
+++ b/.changeset/fruity-baboons-joke.md
@@ -1,0 +1,9 @@
+---
+"@desselbane/composables": patch
+"@desselbane/ts-helpers": patch
+"@desselbane/configs": patch
+"@repo/scripts": patch
+"@repo/changelog": patch
+---
+
+Eslint fail on warnings

--- a/.changeset/lucky-lemons-turn.md
+++ b/.changeset/lucky-lemons-turn.md
@@ -1,0 +1,5 @@
+---
+"@desselbane/configs": minor
+---
+
+Eslint `reportUnusedDisableDirectives` as `error`

--- a/.changeset/open-needles-camp.md
+++ b/.changeset/open-needles-camp.md
@@ -1,0 +1,5 @@
+---
+"@desselbane/configs": minor
+---
+
+Add `@vitest/eslint-plugin-vitest`

--- a/.changeset/witty-cameras-happen.md
+++ b/.changeset/witty-cameras-happen.md
@@ -1,0 +1,5 @@
+---
+"@repo/changelog": patch
+---
+
+Ensure `@desselbane/configs` package is built before linting

--- a/packages/composables/package.json
+++ b/packages/composables/package.json
@@ -8,8 +8,8 @@
     "build": "vite build",
     "test": "vitest run",
     "test:dev": "vitest",
-    "lint": "eslint .",
-    "lint:fix": "eslint --fix .",
+    "lint": "eslint . --max-warnings 0",
+    "lint:fix": "pnpm lint --fix",
     "typecheck:lib": "vue-tsc --noEmit -p tsconfig.lib.json",
     "typecheck:vitest": "vue-tsc --noEmit -p tsconfig.vitest.json"
   },
@@ -31,7 +31,7 @@
     "extends": "../../package.json"
   },
   "lint-staged": {
-    "*": "eslint --fix"
+    "*": "eslint --fix --max-warnings 0"
   },
   "peerDependencies": {
     "vue": "^3.5.0"

--- a/packages/composables/src/use-pagination/use-pagination.l1.spec.ts
+++ b/packages/composables/src/use-pagination/use-pagination.l1.spec.ts
@@ -1,6 +1,6 @@
 import { ref, unref } from 'vue'
 import type { MaybeRef } from 'vue'
-import { expect } from 'vitest'
+import { expect, describe, it } from 'vitest'
 import { noop } from '@desselbane/ts-helpers'
 import {
   InvalidOperationError,
@@ -30,7 +30,7 @@ function usePaginationWithDataSetup<TData>(
   return usePaginationWithData(data, pageSize, options)
 }
 
-describe('usePagination', () => {
+describe(usePagination, () => {
   it.each([
     {
       pageSize: 7,
@@ -110,7 +110,7 @@ describe('usePagination', () => {
 
       expect(() => {
         nextPage()
-      }).toThrowError(InvalidOperationError)
+      }).toThrow(InvalidOperationError)
 
       warnSpy.mockRestore()
     })
@@ -125,7 +125,9 @@ describe('usePagination', () => {
       })
 
       expect(unref(currentPage)).toBe(1)
+
       nextPage()
+
       expect(unref(currentPage)).toBe(1)
     })
 
@@ -352,7 +354,7 @@ describe('usePagination', () => {
 
       expect(() => {
         previousPage()
-      }).toThrowError(InvalidOperationError)
+      }).toThrow(InvalidOperationError)
 
       warnSpy.mockRestore()
     })
@@ -449,7 +451,7 @@ describe('usePagination', () => {
   )
 })
 
-describe('usePaginationWithData', () => {
+describe(usePaginationWithData, () => {
   const defaultData = [1, 2, 3, 4, 5, 6, 7, 8, 9]
 
   describe('data', () => {
@@ -458,7 +460,7 @@ describe('usePaginationWithData', () => {
         pageSize: 4,
       })
 
-      expect(unref(paginatedData)).toEqual([1, 2, 3, 4])
+      expect(unref(paginatedData)).toStrictEqual([1, 2, 3, 4])
     })
 
     it('should be reactive', () => {
@@ -467,11 +469,11 @@ describe('usePaginationWithData', () => {
         pageSize: 4,
       })
 
-      expect(unref(paginatedData)).toEqual([1, 2, 3, 4])
+      expect(unref(paginatedData)).toStrictEqual([1, 2, 3, 4])
 
       data.value[0] = 9
 
-      expect(unref(paginatedData)).toEqual([9, 2, 3, 4])
+      expect(unref(paginatedData)).toStrictEqual([9, 2, 3, 4])
     })
   })
 })

--- a/packages/composables/tsconfig.lib.json
+++ b/packages/composables/tsconfig.lib.json
@@ -1,5 +1,5 @@
 {
   "include": ["src/**/*.ts", "@types", "**/*.vue"],
-  "exclude": ["src/**/*.spec.ts", "**/__mocks__/**/*"],
+  "exclude": ["src/**/*.spec.ts", "**/__mocks__/**/*", "**/*.spec-d.ts"],
   "extends": "@desselbane/configs/tsconfig.bundler-web.tpl.json"
 }

--- a/packages/configs/README.md
+++ b/packages/configs/README.md
@@ -48,7 +48,7 @@ Use a `tsconfig.app.json` for your app files:
 ```json
 {
   "include": ["src/**/*.ts", "@types", "**/*.vue"],
-  "exclude": ["src/**/*.spec.ts"],
+  "exclude": ["src/**/*.spec.ts", "**/__mocks__/**/*", "**/*.spec-d.ts"],
   "extends": "@desselbane/configs/tsconfig.bundler-web.tpl.json"
 }
 ```

--- a/packages/configs/package.json
+++ b/packages/configs/package.json
@@ -75,6 +75,7 @@
   "dependencies": {
     "@eslint/compat": "1.3.1",
     "@eslint/js": "9.31.0",
+    "@vitest/eslint-plugin": "1.3.4",
     "@vue/eslint-config-typescript": "14.6.0",
     "eslint": "9.31.0",
     "eslint-config-prettier": "10.1.5",
@@ -94,10 +95,10 @@
     "zod": "4.0.5"
   },
   "peerDependencies": {
+    "@vue/test-utils": "^2.0.0",
     "tsdown": "^0.12.9",
     "vite": "^5.4.19 || ^6.3.4 || ^7.0.0",
-    "vitest": "^2.1.9 || ^3.0.5",
-    "@vue/test-utils": "^2.0.0"
+    "vitest": "^2.1.9 || ^3.0.5"
   },
   "peerDependenciesMeta": {
     "vite": {

--- a/packages/configs/package.json
+++ b/packages/configs/package.json
@@ -62,15 +62,15 @@
   "scripts": {
     "dev": "tsdown --watch --no-clean",
     "build": "tsdown",
-    "lint": "eslint .",
-    "lint:fix": "eslint --fix .",
+    "lint": "eslint . --max-warnings 0",
+    "lint:fix": "pnpm lint --fix",
     "typecheck:lib": "tsc --noEmit -p tsconfig.lib.json"
   },
   "volta": {
     "extends": "../../package.json"
   },
   "lint-staged": {
-    "*": "eslint --fix"
+    "*": "eslint --fix --max-warnings 0"
   },
   "dependencies": {
     "@eslint/compat": "1.3.1",

--- a/packages/configs/src/eslint.config.tpl.ts
+++ b/packages/configs/src/eslint.config.tpl.ts
@@ -17,6 +17,7 @@ import { flatConfigs as importPluginFlatConfigs } from 'eslint-plugin-import-x'
 import { createTypeScriptImportResolver } from 'eslint-import-resolver-typescript'
 import unusedImports from 'eslint-plugin-unused-imports'
 import eslintPluginUnicorn from 'eslint-plugin-unicorn'
+import vitest from '@vitest/eslint-plugin'
 
 /**
  * How to set up eslint
@@ -121,6 +122,7 @@ export function createEslintConfig(options: Options = {}): Config {
 
   return tsEslint.config(
     eslint.configs.recommended,
+    ...configureVitestPlugin(safeOptions),
     ...configureUnicornPlugin(safeOptions),
     ...configureImportPlugin(safeOptions),
     ...configurePlaywright(safeOptions),
@@ -322,6 +324,37 @@ function configureUnicornPlugin(options: SafeOptions): Config {
   ])
 }
 
+function configureVitestPlugin(options: SafeOptions): Config {
+  return tsEslint.config(
+    {
+      files: options.testMatch, // or any other pattern
+      ...vitest.configs.all,
+      settings: {
+        vitest: {
+          typecheck: true,
+        },
+      },
+    },
+    {
+      files: options.testMatch, // or any other pattern
+      rules: {
+        'vitest/no-disabled-tests': 'error',
+        'vitest/consistent-test-filename': 'off',
+        'vitest/prefer-expect-assertions': 'off',
+        'vitest/no-conditional-expect': 'off',
+        'vitest/no-conditional-in-test': 'off',
+        'vitest/no-conditional-test': 'off',
+        'vitest/prefer-called-with': 'off',
+        'vitest/prefer-to-be-falsy': 'off',
+        'vitest/prefer-to-be-truthy': 'off',
+        'vitest/consistent-test-it': 'off',
+        'vitest/require-hook': 'off',
+        'vitest/max-expects': 'off',
+      },
+    },
+  )
+}
+
 // Needs to come after configure typescript
 function configureNoUnusedImportsPlugin() {
   return tsEslint.config({
@@ -429,6 +462,12 @@ function configureAdditionalRules(options: SafeOptions): Config {
         '@typescript-eslint/no-explicit-any': 'off',
         '@typescript-eslint/no-non-null-assertion': 'off',
         '@typescript-eslint/no-unsafe-return': 'off',
+        'no-empty-pattern': [
+          'error',
+          {
+            allowObjectPatternsAsParameters: true,
+          },
+        ],
       },
     },
     {

--- a/packages/configs/src/eslint.config.tpl.ts
+++ b/packages/configs/src/eslint.config.tpl.ts
@@ -383,6 +383,7 @@ function configureAdditionalRules(options: SafeOptions): Config {
     {
       linterOptions: {
         reportUnusedInlineConfigs: 'error',
+        reportUnusedDisableDirectives: 'error',
       },
     },
   ]

--- a/packages/configs/src/eslint.config.tpl.ts
+++ b/packages/configs/src/eslint.config.tpl.ts
@@ -379,7 +379,13 @@ function configureNoUnusedImportsPlugin() {
 }
 
 function configureAdditionalRules(options: SafeOptions): Config {
-  const config: Config = []
+  const config: Config = [
+    {
+      linterOptions: {
+        reportUnusedInlineConfigs: 'error',
+      },
+    },
+  ]
 
   if (options.useTypeCheckedConfig) {
     config.push(

--- a/packages/configs/src/tsdown.config.tpl.ts
+++ b/packages/configs/src/tsdown.config.tpl.ts
@@ -1,6 +1,5 @@
 import type { UserConfig } from 'tsdown'
 
-// eslint-disable-next-line unicorn/prevent-abbreviations
 export const libConfig = {
   entry: ['src/main.ts'],
   tsconfig: 'tsconfig.lib.json',

--- a/packages/configs/src/vitest.config.tpl.ts
+++ b/packages/configs/src/vitest.config.tpl.ts
@@ -31,6 +31,11 @@ export const defaultOptions = {
     coverage: {
       provider: 'v8',
     },
+    typecheck: {
+      enabled: true,
+      include: ['**/*.spec-d.ts'],
+      tsconfig: 'tsconfig.vitest.json',
+    },
   },
 } as const satisfies VitestConfig
 

--- a/packages/configs/tsconfig.lib.json
+++ b/packages/configs/tsconfig.lib.json
@@ -1,6 +1,6 @@
 {
   "include": ["src/**/*.ts", "@types"],
-  "exclude": ["src/**/*.spec.ts", "**/__mocks__/**/*"],
+  "exclude": ["src/**/*.spec.ts", "**/__mocks__/**/*", "src/**/*.spec-d.ts"],
   "extends": "./tsconfig.bundler-node.tpl.json",
   "compilerOptions": {
     "types": ["vitest/globals", "./vitest-shims.d.ts"]

--- a/packages/configs/turbo/generators/resources/package/addMany/package.json.hbs
+++ b/packages/configs/turbo/generators/resources/package/addMany/package.json.hbs
@@ -21,8 +21,8 @@
 {{/runtimeIsWeb}}
     "test": "vitest run",
     "test:dev": "vitest",
-    "lint": "eslint .",
-    "lint:fix": "eslint --fix .",
+    "lint": "eslint . --max-warnings 0",
+    "lint:fix": "pnpm lint --fix",
     "typecheck:{{packageType}}": "{{#runtimeIsWeb}}vue-tsc{{else}}tsc{{/runtimeIsWeb}} --noEmit -p tsconfig.{{packageType}}.json",
     "typecheck:vitest": "{{#runtimeIsWeb}}vue-tsc{{else}}tsc{{/runtimeIsWeb}} --noEmit -p tsconfig.vitest.json"
   },
@@ -46,7 +46,7 @@
     "extends": "{{ voltaPath }}"
   },
   "lint-staged": {
-    "*": "eslint --fix"
+    "*": "eslint --fix --max-warnings 0"
   },
   "devDependencies": {
     "@desselbane/configs": "workspace:*"

--- a/packages/configs/turbo/generators/resources/package/tsconfig.runtime.json.hbs
+++ b/packages/configs/turbo/generators/resources/package/tsconfig.runtime.json.hbs
@@ -1,5 +1,5 @@
 {
   "include": ["src/**/*.ts", "@types"{{#runtimeIsWeb}}, "**/*.vue"{{/runtimeIsWeb}}],
-  "exclude": ["src/**/*.spec.ts", "**/__mocks__/**/*"],
+  "exclude": ["src/**/*.spec.ts", "**/__mocks__/**/*", "src/**/*.spec-d.ts"],
   "extends": "@desselbane/configs/tsconfig.{{runtime}}.tpl.json"
 }

--- a/packages/configs/vitest-shims.d.ts
+++ b/packages/configs/vitest-shims.d.ts
@@ -5,4 +5,5 @@ declare module 'vitest' {
   interface Assertion<T = any> extends CustomMatchers<T> {}
   interface AsymmetricMatchersContaining<T = any> extends CustomMatchers<T> {}
   interface ExpectStatic extends CustomMatchers<T> {}
+  type Use<T> = (value: T) => Promise<void>
 }

--- a/packages/scripts/__mocks__/fs.ts
+++ b/packages/scripts/__mocks__/fs.ts
@@ -1,0 +1,11 @@
+export const globSync = vi.fn<() => string[]>(() => {
+  throw new Error('Mock globSync not initialized')
+})
+export const readFileSync = vi.fn<(path: string) => Buffer>(() => {
+  throw new Error('Mock readFileSync not initialized')
+})
+export const writeFileSync = vi.fn<(path: string, content: string) => void>(
+  () => {
+    throw new Error('Mock writeFileSync not initialized')
+  },
+)

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "test": "vitest run",
     "test:dev": "vitest",
-    "lint": "eslint .",
-    "lint:fix": "eslint --fix .",
+    "lint": "eslint . --max-warnings 0",
+    "lint:fix": "pnpm lint --fix",
     "typecheck:lib": "tsc --noEmit -p tsconfig.lib.json",
     "typecheck:vitest": "tsc --noEmit -p tsconfig.vitest.json",
     "reformat-changelogs": "node src/reformat-changelogs-cli.ts",
@@ -23,7 +23,7 @@
     "extends": "../../package.json"
   },
   "lint-staged": {
-    "*": "eslint --fix"
+    "*": "eslint --fix --max-warnings 0"
   },
   "devDependencies": {
     "@desselbane/configs": "workspace:*",

--- a/packages/scripts/tsconfig.lib.json
+++ b/packages/scripts/tsconfig.lib.json
@@ -1,6 +1,6 @@
 {
   "include": ["src/**/*.ts", "@types"],
-  "exclude": ["src/**/*.spec.ts", "**/__mocks__/**/*"],
+  "exclude": ["src/**/*.spec.ts", "**/__mocks__/**/*", "**/*.spec-d.ts"],
   "extends": "@desselbane/configs/tsconfig.node.tpl.json",
   "compilerOptions": {
     "allowImportingTsExtensions": true

--- a/packages/ts-helpers/package.json
+++ b/packages/ts-helpers/package.json
@@ -8,8 +8,8 @@
     "build": "tsdown",
     "test": "vitest run",
     "test:dev": "vitest",
-    "lint": "eslint .",
-    "lint:fix": "eslint --fix .",
+    "lint": "eslint . --max-warnings 0",
+    "lint:fix": "pnpm lint --fix",
     "typecheck:lib": "tsc --noEmit -p tsconfig.lib.json",
     "typecheck:vitest": "tsc --noEmit -p tsconfig.vitest.json"
   },
@@ -31,7 +31,7 @@
     "extends": "../../package.json"
   },
   "lint-staged": {
-    "*": "eslint --fix"
+    "*": "eslint --fix --max-warnings 0"
   },
   "devDependencies": {
     "@desselbane/configs": "workspace:*",

--- a/packages/ts-helpers/src/array/is-included.l1.spec.ts
+++ b/packages/ts-helpers/src/array/is-included.l1.spec.ts
@@ -1,8 +1,9 @@
-import { expect, expectTypeOf } from 'vitest'
+import { expect, expectTypeOf, describe, it } from 'vitest'
 import { isIncluded } from './is-included'
 
 describe('is-included', () => {
   const data = ['foo', 'bar'] as const
+
   it('should be false if element is not included', () => {
     expect(isIncluded(data, 'baz')).toBe(false)
   })

--- a/packages/ts-helpers/src/assertions/null-or-undefined.l1.spec.ts
+++ b/packages/ts-helpers/src/assertions/null-or-undefined.l1.spec.ts
@@ -1,198 +1,152 @@
 /* eslint-disable unicorn/no-null,unicorn/no-useless-undefined */
-import { describe, expect, expectTypeOf } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import {
   assertNotNil,
-  assertPropertiesNotNil as assertPropertiesNotNil,
+  assertPropertiesNotNil,
   assertNil,
 } from './null-or-undefined'
 import { AssertionError } from './assertion-error'
 
-describe('assert', () => {
-  describe('assertPropsNotNil', () => {
-    type TypeUnderTest = {
-      bar: string | null
-      baz: string | undefined
-      foo?: string
-      quz: string | null
-    }
+describe(assertPropertiesNotNil, () => {
+  type TypeUnderTest = {
+    bar: string | null
+    baz: string | undefined
+    foo?: string
+    quz: string | null
+  }
 
-    const defaultData: TypeUnderTest = {
-      bar: 'bar',
-      foo: 'foo',
-      quz: 'quz',
-      baz: 'baz',
-    }
+  const defaultData: TypeUnderTest = {
+    bar: 'bar',
+    foo: 'foo',
+    quz: 'quz',
+    baz: 'baz',
+  }
 
-    it.each<{ title: string; data: TypeUnderTest; prop: keyof TypeUnderTest }>([
-      {
-        title: 'bar = null',
-        data: { ...defaultData, bar: null },
-        prop: 'bar',
-      },
-      {
-        title: 'baz = undefined',
-        data: { ...defaultData, baz: undefined },
-        prop: 'baz',
-      },
+  it.each<{ title: string; data: TypeUnderTest; prop: keyof TypeUnderTest }>([
+    {
+      title: 'bar = null',
+      data: { ...defaultData, bar: null },
+      prop: 'bar',
+    },
+    {
+      title: 'baz = undefined',
+      data: { ...defaultData, baz: undefined },
+      prop: 'baz',
+    },
 
-      {
-        title: 'foo = undefined',
-        data: { ...defaultData, foo: undefined },
-        prop: 'foo',
-      },
-    ])('should throw if $title', ({ data, prop }) => {
-      expect(() => {
-        assertPropertiesNotNil(data, prop)
-      }).toThrowError(AssertionError)
-    })
-
-    it.each<{ title: string; data: { foo: unknown } }>([
-      {
-        title: 'baz = ""',
-        data: { foo: '' },
-      },
-      {
-        title: 'foo = 0',
-        data: { foo: 0 },
-      },
-      {
-        title: 'foo = -0',
-        data: { foo: -0 },
-      },
-      {
-        title: 'foo = NaN',
-        data: { foo: Number.NaN },
-      },
-      {
-        title: 'foo = 0 (bigInt)',
-        data: { foo: 0n },
-      },
-      {
-        title: 'foo = false',
-        data: { foo: false },
-      },
-    ])('should not throw if $title', ({ data }) => {
-      expect(() => {
-        assertPropertiesNotNil(data, 'foo')
-      }).not.toThrowError(AssertionError)
-    })
-
-    // Skipped as this test only tests types
-    it.skip('should mark props as safe when they are not null', () => {
-      const foo: {
-        bar: string | null
-        baz: string | undefined
-        foo?: string
-        quz: string | null
-      } = {
-        bar: 'bar',
-        foo: 'foo',
-        quz: 'quz',
-        baz: 'baz',
-      }
-
-      assertPropertiesNotNil(foo, 'bar', 'baz', 'foo')
-
-      expectTypeOf(foo.bar).toEqualTypeOf<string>()
-      expectTypeOf(foo.baz).toEqualTypeOf<string>()
-      expectTypeOf(foo.foo).toEqualTypeOf<string>()
-      expectTypeOf(foo.quz).toEqualTypeOf<null | string>()
-    })
+    {
+      title: 'foo = undefined',
+      data: { ...defaultData, foo: undefined },
+      prop: 'foo',
+    },
+  ])('should throw if $title', ({ data, prop }) => {
+    expect(() => {
+      assertPropertiesNotNil(data, prop)
+    }).toThrow(AssertionError)
   })
 
-  describe('assertNotNil', () => {
-    it('should throw if null is passed', () => {
-      expect(() => {
-        assertNotNil(null)
-      }).toThrowError(AssertionError)
-    })
+  it.each<{ title: string; data: { foo: unknown } }>([
+    {
+      title: 'baz = ""',
+      data: { foo: '' },
+    },
+    {
+      title: 'foo = 0',
+      data: { foo: 0 },
+    },
+    {
+      title: 'foo = -0',
+      data: { foo: -0 },
+    },
+    {
+      title: 'foo = NaN',
+      data: { foo: Number.NaN },
+    },
+    {
+      title: 'foo = 0 (bigInt)',
+      data: { foo: 0n },
+    },
+    {
+      title: 'foo = false',
+      data: { foo: false },
+    },
+  ])('should not throw if $title', ({ data }) => {
+    expect(() => {
+      assertPropertiesNotNil(data, 'foo')
+    }).not.toThrow(AssertionError)
+  })
+})
 
-    it('should throw if undefined is passed', () => {
-      expect(() => {
-        assertNotNil(undefined)
-      }).toThrowError(AssertionError)
-    })
-
-    it.each(['', 0, -0, 0n, Number.NaN, false])(
-      'should not throw if falsy value is passed: %s',
-      (falsyValue) => {
-        expect(() => {
-          assertNotNil(falsyValue)
-        }).not.toThrowError(AssertionError)
-      },
-    )
-
-    it('should have message and context if it was passed', () => {
-      expect(() => {
-        assertNotNil(undefined, 'Foobar', { customTestContext: 'foobar' })
-      }).toThrowError(
-        expect.objectContaining({
-          name: 'AssertionError',
-          message: 'Foobar',
-          context: {
-            customTestContext: 'foobar',
-          },
-        }),
-      )
-    })
-
-    // Skipped as this test only tests types
-    it.skip('should correctly assert type', () => {
-      const foo = 'bar' as unknown as string | null
-
-      expectTypeOf(foo).toEqualTypeOf<string | null>()
-
-      assertNotNil(foo)
-
-      expectTypeOf(foo).toBeString()
-    })
+describe(assertNotNil, () => {
+  it('should throw if null is passed', () => {
+    expect(() => {
+      assertNotNil(null)
+    }).toThrow(AssertionError)
   })
 
-  describe('assertNil', () => {
-    it('should not throw if null is passed', () => {
-      expect(() => {
-        assertNil(null)
-      }).not.toThrowError(AssertionError)
-    })
+  it('should throw if undefined is passed', () => {
+    expect(() => {
+      assertNotNil(undefined)
+    }).toThrow(AssertionError)
+  })
 
-    it('should not throw if undefined is passed', () => {
+  it.each(['', 0, -0, 0n, Number.NaN, false])(
+    'should not throw if falsy value is passed: %s',
+    (falsyValue) => {
       expect(() => {
-        assertNil(undefined)
-      }).not.toThrowError(AssertionError)
-    })
+        assertNotNil(falsyValue)
+      }).not.toThrow(AssertionError)
+    },
+  )
 
-    it.each(['', 0, -0, 0n, Number.NaN, false])(
-      'should throw if falsy but non nullish value is passed: %s',
-      (falsyValue) => {
-        expect(() => {
-          assertNil(falsyValue)
-        }).toThrowError(AssertionError)
-      },
+  it('should have message and context if it was passed', () => {
+    expect(() => {
+      assertNotNil(undefined, 'Foobar', { customTestContext: 'foobar' })
+    }).toThrow(
+      expect.objectContaining({
+        name: 'AssertionError',
+        message: 'Foobar',
+        context: {
+          customTestContext: 'foobar',
+        },
+      }),
     )
+  })
+})
 
-    it('should have message and context if it was passed', () => {
+describe(assertNil, () => {
+  it('should not throw if null is passed', () => {
+    expect(() => {
+      assertNil(null)
+    }).not.toThrow(AssertionError)
+  })
+
+  it('should not throw if undefined is passed', () => {
+    expect(() => {
+      assertNil(undefined)
+    }).not.toThrow(AssertionError)
+  })
+
+  it.each(['', 0, -0, 0n, Number.NaN, false])(
+    'should throw if falsy but non nullish value is passed: %s',
+    (falsyValue) => {
       expect(() => {
-        assertNil('not nil', 'Foobar', { customTestContext: 'foobar' })
-      }).toThrowError(
-        expect.objectContaining({
-          name: 'AssertionError',
-          message: 'Foobar',
-          context: {
-            customTestContext: 'foobar',
-          },
-        }),
-      )
-    })
+        assertNil(falsyValue)
+      }).toThrow(AssertionError)
+    },
+  )
 
-    // Skipped as this test only tests types
-    it.skip('should correctly assert type', () => {
-      const foo = null as unknown as string | null
-
-      expectTypeOf(foo).toEqualTypeOf<string | null>()
-
-      assertNil(foo)
-
-      expectTypeOf(foo).toBeNullable()
-    })
+  it('should have message and context if it was passed', () => {
+    expect(() => {
+      assertNil('not nil', 'Foobar', { customTestContext: 'foobar' })
+    }).toThrow(
+      expect.objectContaining({
+        name: 'AssertionError',
+        message: 'Foobar',
+        context: {
+          customTestContext: 'foobar',
+        },
+      }),
+    )
   })
 })

--- a/packages/ts-helpers/src/assertions/null-or-undefined.spec-d.ts
+++ b/packages/ts-helpers/src/assertions/null-or-undefined.spec-d.ts
@@ -1,0 +1,55 @@
+/* eslint-disable unicorn/no-null */
+
+import { describe, expectTypeOf, it } from 'vitest'
+import {
+  assertNil,
+  assertNotNil,
+  assertPropertiesNotNil,
+} from './null-or-undefined'
+
+describe(assertPropertiesNotNil, () => {
+  it('should mark props as safe when they are not null', () => {
+    const foo: {
+      bar: string | null
+      baz: string | undefined
+      foo?: string
+      quz: string | null
+    } = {
+      bar: 'bar',
+      foo: 'foo',
+      quz: 'quz',
+      baz: 'baz',
+    }
+
+    assertPropertiesNotNil(foo, 'bar', 'baz', 'foo')
+
+    expectTypeOf(foo.bar).toEqualTypeOf<string>()
+    expectTypeOf(foo.baz).toEqualTypeOf<string>()
+    expectTypeOf(foo.foo).toEqualTypeOf<string>()
+    expectTypeOf(foo.quz).toEqualTypeOf<null | string>()
+  })
+})
+
+describe(assertNotNil, () => {
+  it('should correctly assert type', () => {
+    const foo = 'bar' as unknown as string | null
+
+    expectTypeOf(foo).toEqualTypeOf<string | null>()
+
+    assertNotNil(foo)
+
+    expectTypeOf(foo).toBeString()
+  })
+})
+
+describe(assertNil, () => {
+  it('should correctly assert type', () => {
+    const foo = null as unknown as string | null
+
+    expectTypeOf(foo).toEqualTypeOf<string | null>()
+
+    assertNil(foo)
+
+    expectTypeOf(foo).toBeNullable()
+  })
+})

--- a/packages/ts-helpers/src/assertions/strings.l1.spec.ts
+++ b/packages/ts-helpers/src/assertions/strings.l1.spec.ts
@@ -1,173 +1,163 @@
 /* eslint-disable unicorn/no-null */
-import { describe, expect, expectTypeOf } from 'vitest'
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import { AssertionError } from './assertion-error'
 import {
   isNilOrWhitespace,
   assertIsString,
   assertIsNullableString,
 } from './strings'
-import type { Nullable } from './strings'
 
-describe('strings', () => {
-  describe('isNilOrWhitespace', () => {
-    it.each([
-      {
-        input: '',
-        expectedResult: true,
-      },
-      {
-        input: '  ',
-        expectedResult: true,
-      },
-      {
-        input: null,
-        expectedResult: true,
-      },
-      {
-        input: undefined,
-        expectedResult: true,
-      },
-      {
-        // Non-breakable space is still just a space
-        input: '\u00A0',
-        expectedResult: true,
-      },
-      {
-        input: 'f',
-        expectedResult: false,
-      },
-    ])(
-      `should return $expectedResult for $input`,
-      ({ input, expectedResult }) => {
-        expect(isNilOrWhitespace(input)).toBe(expectedResult)
-      },
+describe(isNilOrWhitespace, () => {
+  it.each([
+    {
+      input: '',
+      expectedResult: true,
+    },
+    {
+      input: '  ',
+      expectedResult: true,
+    },
+    {
+      input: null,
+      expectedResult: true,
+    },
+    {
+      input: undefined,
+      expectedResult: true,
+    },
+    {
+      // Non-breakable space is still just a space
+      input: '\u00A0',
+      expectedResult: true,
+    },
+    {
+      input: 'f',
+      expectedResult: false,
+    },
+  ])(
+    `should return $expectedResult for $input`,
+    ({ input, expectedResult }) => {
+      expect(isNilOrWhitespace(input)).toBe(expectedResult)
+    },
+  )
+})
+
+describe(assertIsString, () => {
+  it.each([
+    {
+      title: 'null',
+      value: null,
+    },
+    {
+      title: 'undefined',
+      value: undefined,
+    },
+    {
+      title: 'number',
+      value: 3,
+    },
+    {
+      title: 'boolean',
+      value: true,
+    },
+    {
+      title: 'object',
+      value: { foo: true },
+    },
+    {
+      title: 'array',
+      value: [''],
+    },
+  ])('should throw for $title', ({ value }) => {
+    expect(() => {
+      assertIsString(value)
+    }).toThrow(AssertionError)
+  })
+
+  it('should not throw for strings', () => {
+    const value = 'test' as unknown as string | number
+
+    expect(() => {
+      assertIsString(value)
+    }).not.toThrow()
+
+    assertIsString(value)
+
+    expectTypeOf(value).toBeString()
+  })
+
+  it('should throw correct error', () => {
+    expect(() => {
+      assertIsString(3)
+    }).toThrow(
+      expect.objectContaining({
+        name: 'AssertionError',
+        message: 'Expected value to be string',
+        context: {
+          expectedType: 'string',
+          actualType: 'number',
+        },
+      }),
     )
   })
+})
 
-  describe('assertIsString', () => {
-    it.each([
-      {
-        title: 'null',
-        value: null,
-      },
-      {
-        title: 'undefined',
-        value: undefined,
-      },
-      {
-        title: 'number',
-        value: 3,
-      },
-      {
-        title: 'boolean',
-        value: true,
-      },
-      {
-        title: 'object',
-        value: { foo: true },
-      },
-      {
-        title: 'array',
-        value: [''],
-      },
-    ])('should throw for $title', ({ value }) => {
-      expect(() => {
-        assertIsString(value)
-      }).toThrow()
-    })
-
-    it('should not throw for strings', () => {
-      const value = 'test' as unknown as string | number
-
-      expect(() => {
-        assertIsString(value)
-      }).not.toThrow()
-
-      assertIsString(value)
-
-      expectTypeOf(value).toBeString()
-    })
-
-    it('should throw correct error', () => {
-      expect(() => {
-        assertIsString(3)
-      }).toThrowError(
-        expect.objectContaining({
-          name: 'AssertionError',
-          message: 'Expected value to be string',
-          context: {
-            expectedType: 'string',
-            actualType: 'number',
-          },
-        }),
-      )
-    })
+describe(assertIsNullableString, () => {
+  it.each([
+    {
+      title: 'number',
+      value: 3,
+    },
+    {
+      title: 'boolean',
+      value: true,
+    },
+    {
+      title: 'object',
+      value: { foo: true },
+    },
+    {
+      title: 'array',
+      value: [''],
+    },
+  ])('should throw for $title', ({ value }) => {
+    expect(() => {
+      assertIsNullableString(value)
+    }).toThrow(AssertionError)
   })
 
-  describe('assertIsNullableString', () => {
-    it.each([
-      {
-        title: 'number',
-        value: 3,
-      },
-      {
-        title: 'boolean',
-        value: true,
-      },
-      {
-        title: 'object',
-        value: { foo: true },
-      },
-      {
-        title: 'array',
-        value: [''],
-      },
-    ])('should throw for $title', ({ value }) => {
-      expect(() => {
-        assertIsNullableString(value)
-      }).toThrow()
-    })
-
-    it.each([
-      {
-        title: 'null',
-        value: null,
-      },
-      {
-        title: 'undefined',
-        value: undefined,
-      },
-      {
-        title: 'string',
-        value: 'foo',
-      },
-    ])('should not throw for $title', ({ value }) => {
-      expect(() => {
-        assertIsNullableString(value)
-      }).not.toThrow()
-    })
-
-    it.skip('should assert the type correctly', () => {
-      const value = 'test' as unknown as Nullable<string> | number
-
+  it.each([
+    {
+      title: 'null',
+      value: null,
+    },
+    {
+      title: 'undefined',
+      value: undefined,
+    },
+    {
+      title: 'string',
+      value: 'foo',
+    },
+  ])('should not throw for $title', ({ value }) => {
+    expect(() => {
       assertIsNullableString(value)
+    }).not.toThrow()
+  })
 
-      expectTypeOf(value).toExtend<Nullable<string>>()
-    })
-
-    it('should throw correct error', () => {
-      expect(() => {
-        assertIsNullableString(3)
-      }).toThrowError(
-        expect.objectContaining({
-          name: 'AssertionError',
-          message: 'Expected value to be string | null | undefined',
-          context: {
-            expectedType: 'string | null | undefined',
-            actualType: 'number',
-            actualValue: 3,
-          },
-        }),
-      )
-    })
+  it('should throw correct error', () => {
+    expect(() => {
+      assertIsNullableString(3)
+    }).toThrow(
+      expect.objectContaining({
+        name: 'AssertionError',
+        message: 'Expected value to be string | null | undefined',
+        context: {
+          expectedType: 'string | null | undefined',
+          actualType: 'number',
+          actualValue: 3,
+        },
+      }),
+    )
   })
 })

--- a/packages/ts-helpers/src/assertions/strings.spec-d.ts
+++ b/packages/ts-helpers/src/assertions/strings.spec-d.ts
@@ -1,0 +1,13 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import { assertIsNullableString } from './strings'
+import type { Nullable } from './strings'
+
+describe(assertIsNullableString, () => {
+  it('should assert the type correctly', () => {
+    const value = 'test' as unknown as Nullable<string> | number
+
+    assertIsNullableString(value)
+
+    expectTypeOf(value).toExtend<Nullable<string>>()
+  })
+})

--- a/packages/ts-helpers/src/lazy/lazy.l1.spec.ts
+++ b/packages/ts-helpers/src/lazy/lazy.l1.spec.ts
@@ -1,9 +1,11 @@
-import { expect } from 'vitest'
+import { expect, describe, it } from 'vitest'
 import { lazy } from './lazy'
 
-describe('lazy', () => {
+describe(lazy, () => {
   it('should create the value only once its accessed', () => {
-    const spy = vi.fn().mockReturnValue('ae5fc249-2fc4-47f5-8b75-b7a0a16f3a3e')
+    const spy = vi
+      .fn<() => string>()
+      .mockReturnValue('ae5fc249-2fc4-47f5-8b75-b7a0a16f3a3e')
     const lazyValueGetter = lazy(spy)
 
     expect(spy).not.toHaveBeenCalled()
@@ -11,24 +13,29 @@ describe('lazy', () => {
     const lazyValue = lazyValueGetter()
 
     expect(lazyValue).toBe('ae5fc249-2fc4-47f5-8b75-b7a0a16f3a3e')
-    expect(spy).toHaveBeenCalledOnce()
+    expect(spy).toHaveBeenCalledTimes(1)
 
     lazyValueGetter()
 
-    expect(spy).toHaveBeenCalledOnce()
+    expect(spy).toHaveBeenCalledTimes(1)
   })
 
   it('should only create the value once', () => {
-    const spy = vi.fn().mockReturnValue('ae5fc249-2fc4-47f5-8b75-b7a0a16f3a3e')
+    const spy = vi
+      .fn<() => string>()
+      .mockReturnValue('ae5fc249-2fc4-47f5-8b75-b7a0a16f3a3e')
     const lazyValueGetter = lazy(spy)
 
     lazyValueGetter()
-    expect(spy).toHaveBeenCalledOnce()
+
+    expect(spy).toHaveBeenCalledTimes(1)
 
     lazyValueGetter()
-    expect(spy).toHaveBeenCalledOnce()
+
+    expect(spy).toHaveBeenCalledTimes(1)
 
     lazyValueGetter()
-    expect(spy).toHaveBeenCalledOnce()
+
+    expect(spy).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/ts-helpers/src/objects/keylike-to-string.l1.spec.ts
+++ b/packages/ts-helpers/src/objects/keylike-to-string.l1.spec.ts
@@ -1,7 +1,7 @@
-import { expect } from 'vitest'
+import { expect, describe } from 'vitest'
 import { keylikeToString } from './keylike-to-string'
 
-describe('keylikeToString', () => {
+describe(keylikeToString, () => {
   it.each([
     {
       title: 'Returns strings as is',

--- a/packages/ts-helpers/src/safe-try/finally-for-maybe-promise.l1.spec.ts
+++ b/packages/ts-helpers/src/safe-try/finally-for-maybe-promise.l1.spec.ts
@@ -1,50 +1,50 @@
-import { expect } from 'vitest'
+import { expect, describe, it } from 'vitest'
 import { noop } from '../main'
 import { finallyForMaybePromise } from './finally-for-maybe-promise'
 
-describe('finallyForMaybePromise', () => {
+describe(finallyForMaybePromise, () => {
   describe('sync', () => {
     it('should call finally without error', () => {
-      const finallyMock = vi.fn()
+      const finallyMock = vi.fn<VoidFunction>()
 
       finallyForMaybePromise(noop, finallyMock)
 
-      expect(finallyMock).toHaveBeenCalledOnce()
+      expect(finallyMock).toHaveBeenCalledTimes(1)
     })
 
     it('should call finally with error', () => {
-      const finallyMock = vi.fn()
+      const finallyMock = vi.fn<VoidFunction>()
 
       expect(() =>
         finallyForMaybePromise(() => {
           throw new Error('test')
         }, finallyMock),
-      ).toThrow()
+      ).toThrow('test')
 
-      expect(finallyMock).toHaveBeenCalledOnce()
+      expect(finallyMock).toHaveBeenCalledTimes(1)
     })
   })
 
   describe('async', () => {
     it('should call finally without error', async () => {
-      const finallyMock = vi.fn()
+      const finallyMock = vi.fn<VoidFunction>()
 
       await finallyForMaybePromise(() => Promise.resolve('foo'), finallyMock)
 
-      expect(finallyMock).toHaveBeenCalledOnce()
+      expect(finallyMock).toHaveBeenCalledTimes(1)
     })
 
     it('should call finally with error', async () => {
-      const finallyMock = vi.fn()
+      const finallyMock = vi.fn<VoidFunction>()
 
       await expect(() =>
         finallyForMaybePromise(
           () => Promise.reject(new Error('test')),
           finallyMock,
         ),
-      ).rejects.toThrow()
+      ).rejects.toThrow('test')
 
-      expect(finallyMock).toHaveBeenCalledOnce()
+      expect(finallyMock).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/packages/ts-helpers/src/safe-try/safe-try.l1.spec.ts
+++ b/packages/ts-helpers/src/safe-try/safe-try.l1.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, expectTypeOf } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { safeTry, safeTryAsync } from './safe-try'
 
 const testFunctionBadSync: () => void = () => {
@@ -14,7 +14,7 @@ const testFunctionBadAsync: () => Promise<void> = async () => {
 const testFunctionGoodAsync: () => Promise<string> = () =>
   Promise.resolve('test')
 
-describe('safeTry', () => {
+describe(safeTry, () => {
   it('should not throw', () => {
     expect(() => safeTry(testFunctionBadSync)).not.toThrow()
   })
@@ -32,17 +32,6 @@ describe('safeTry', () => {
 
       expect(data).toBe('test')
     })
-
-    it.skip('has the correct typings', () => {
-      const [error, data] = safeTry(testFunctionGoodSync)
-
-      expectTypeOf(error).toBeNullable()
-      expectTypeOf(data).toBeNullable()
-
-      if (error == undefined) {
-        expectTypeOf(data).not.toBeNullable()
-      }
-    })
   })
 
   describe('object', () => {
@@ -58,133 +47,78 @@ describe('safeTry', () => {
 
       expect(data).toBe('test')
     })
-
-    it.skip('has the correct typings', () => {
-      const { error, data } = safeTry(testFunctionGoodSync)
-
-      expectTypeOf(error).toBeNullable()
-      expectTypeOf(data).toBeNullable()
-
-      if (error == undefined) {
-        expectTypeOf(data).not.toBeNullable()
-      }
-    })
   })
 })
 
-describe('safeTryAsync', () => {
+describe(safeTryAsync, () => {
   it('should not throw', async () => {
     await expect(
       safeTryAsync(() => testFunctionBadAsync()),
     ).resolves.not.toThrow()
 
     await expect(safeTryAsync(testFunctionBadAsync())).resolves.not.toThrow()
-  })
 
-  describe('generator function', () => {
-    describe('array', () => {
-      it('should catch and return a thrown error ', async () => {
-        const [error] = await safeTryAsync(testFunctionBadAsync)
+    describe('generator function', () => {
+      describe('array', () => {
+        it('should catch and return a thrown error ', async () => {
+          const [error] = await safeTryAsync(testFunctionBadAsync)
 
-        expect(error).toBeInstanceOf(Error)
-        expect(error?.message).toBe('test error')
+          expect(error).toBeInstanceOf(Error)
+          expect(error?.message).toBe('test error')
+        })
+
+        it('should return the data if no error is thrown', async () => {
+          const [, data] = await safeTryAsync(testFunctionGoodAsync)
+
+          expect(data).toBe('test')
+        })
       })
 
-      it('should return the data if no error is thrown', async () => {
-        const [, data] = await safeTryAsync(testFunctionGoodAsync)
+      describe('object', () => {
+        it('should catch and return a thrown error ', async () => {
+          const { error } = await safeTryAsync(testFunctionBadAsync)
 
-        expect(data).toBe('test')
-      })
+          expect(error).toBeInstanceOf(Error)
+          expect(error?.message).toBe('test error')
+        })
 
-      it.skip('has the correct typings', async () => {
-        const [error, data] = await safeTryAsync(testFunctionGoodAsync)
+        it('should return the data if no error is thrown', async () => {
+          const { data } = await safeTryAsync(testFunctionGoodAsync)
 
-        expectTypeOf(error).toBeNullable()
-        expectTypeOf(data).toBeNullable()
-
-        if (error == undefined) {
-          expectTypeOf(data).not.toBeNullable()
-        }
-      })
-    })
-
-    describe('object', () => {
-      it('should catch and return a thrown error ', async () => {
-        const { error } = await safeTryAsync(testFunctionBadAsync)
-
-        expect(error).toBeInstanceOf(Error)
-        expect(error?.message).toBe('test error')
-      })
-
-      it('should return the data if no error is thrown', async () => {
-        const { data } = await safeTryAsync(testFunctionGoodAsync)
-
-        expect(data).toBe('test')
-      })
-
-      it.skip('has the correct typings', async () => {
-        const { error, data } = await safeTryAsync(testFunctionGoodAsync)
-
-        expectTypeOf(error).toBeNullable()
-        expectTypeOf(data).toBeNullable()
-
-        if (error == undefined) {
-          expectTypeOf(data).not.toBeNullable()
-        }
-      })
-    })
-  })
-
-  describe('plain promise', () => {
-    describe('array', () => {
-      it('should catch and return a thrown error ', async () => {
-        const [error] = await safeTryAsync(testFunctionBadAsync())
-
-        expect(error).toBeInstanceOf(Error)
-        expect(error?.message).toBe('test error')
-      })
-
-      it('should return the data if no error is thrown', async () => {
-        const [, data] = await safeTryAsync(testFunctionGoodAsync())
-
-        expect(data).toBe('test')
-      })
-
-      it.skip('has the correct typings', async () => {
-        const [error, data] = await safeTryAsync(testFunctionGoodAsync())
-
-        expectTypeOf(error).toBeNullable()
-        expectTypeOf(data).toBeNullable()
-
-        if (error == undefined) {
-          expectTypeOf(data).not.toBeNullable()
-        }
+          expect(data).toBe('test')
+        })
       })
     })
 
-    describe('object', () => {
-      it('should catch and return a thrown error ', async () => {
-        const { error } = await safeTryAsync(testFunctionBadAsync())
+    describe('plain promise', () => {
+      describe('array', () => {
+        it('should catch and return a thrown error ', async () => {
+          const [error] = await safeTryAsync(testFunctionBadAsync())
 
-        expect(error).toBeInstanceOf(Error)
-        expect(error?.message).toBe('test error')
+          expect(error).toBeInstanceOf(Error)
+          expect(error?.message).toBe('test error')
+        })
+
+        it('should return the data if no error is thrown', async () => {
+          const [, data] = await safeTryAsync(testFunctionGoodAsync())
+
+          expect(data).toBe('test')
+        })
       })
 
-      it('should return the data if no error is thrown', async () => {
-        const { data } = await safeTryAsync(testFunctionGoodAsync())
+      describe('object', () => {
+        it('should catch and return a thrown error ', async () => {
+          const { error } = await safeTryAsync(testFunctionBadAsync())
 
-        expect(data).toBe('test')
-      })
+          expect(error).toBeInstanceOf(Error)
+          expect(error?.message).toBe('test error')
+        })
 
-      it.skip('has the correct typings', async () => {
-        const { error, data } = await safeTryAsync(testFunctionGoodAsync())
+        it('should return the data if no error is thrown', async () => {
+          const { data } = await safeTryAsync(testFunctionGoodAsync())
 
-        expectTypeOf(error).toBeNullable()
-        expectTypeOf(data).toBeNullable()
-
-        if (error == undefined) {
-          expectTypeOf(data).not.toBeNullable()
-        }
+          expect(data).toBe('test')
+        })
       })
     })
   })

--- a/packages/ts-helpers/src/safe-try/safe-try.spec-d.ts
+++ b/packages/ts-helpers/src/safe-try/safe-try.spec-d.ts
@@ -1,0 +1,93 @@
+import { expectTypeOf, describe, it } from 'vitest'
+import { safeTry, safeTryAsync } from './safe-try'
+
+const testFunctionGoodSync: () => string = () => 'test'
+
+const testFunctionGoodAsync: () => Promise<string> = () =>
+  Promise.resolve('test')
+
+describe(safeTry, () => {
+  describe('array', () => {
+    it('has the correct typings', () => {
+      const [error, data] = safeTry(testFunctionGoodSync)
+
+      expectTypeOf(error).toBeNullable()
+      expectTypeOf(data).toBeNullable()
+
+      if (error == undefined) {
+        expectTypeOf(data).not.toBeNullable()
+      }
+    })
+  })
+
+  describe('object', () => {
+    it('has the correct typings', () => {
+      const { error, data } = safeTry(testFunctionGoodSync)
+
+      expectTypeOf(error).toBeNullable()
+      expectTypeOf(data).toBeNullable()
+
+      if (error == undefined) {
+        expectTypeOf(data).not.toBeNullable()
+      }
+    })
+  })
+})
+
+describe(safeTryAsync, () => {
+  describe('generator function', () => {
+    describe('array', () => {
+      it('has the correct typings', async () => {
+        const [error, data] = await safeTryAsync(testFunctionGoodAsync)
+
+        expectTypeOf(error).toBeNullable()
+        expectTypeOf(data).toBeNullable()
+
+        if (error == undefined) {
+          expectTypeOf(data).not.toBeNullable()
+        }
+      })
+    })
+
+    describe('object', () => {
+      it('has the correct typings', async () => {
+        const { error, data } = await safeTryAsync(testFunctionGoodAsync)
+
+        expectTypeOf(error).toBeNullable()
+        expectTypeOf(data).toBeNullable()
+
+        if (error == undefined) {
+          expectTypeOf(data).not.toBeNullable()
+        }
+      })
+    })
+  })
+
+  describe('plain promise', () => {
+    describe('array', () => {
+      it('has the correct typings', async () => {
+        const [error, data] = await safeTryAsync(testFunctionGoodAsync())
+
+        expectTypeOf(error).toBeNullable()
+        expectTypeOf(data).toBeNullable()
+
+        if (error == undefined) {
+          expectTypeOf(data).not.toBeNullable()
+        }
+      })
+    })
+
+    describe('object', () => {
+      it('has the correct typings', async () => {
+        const { error, data } = await safeTryAsync(testFunctionGoodAsync())
+
+        expectTypeOf(error).toBeNullable()
+        expectTypeOf(data).toBeNullable()
+
+        if (error == undefined) {
+          expectTypeOf(data).not.toBeNullable()
+        }
+      })
+    })
+  })
+})

--- a/packages/ts-helpers/src/serde/circular-reference-replacer.l1.spec.ts
+++ b/packages/ts-helpers/src/serde/circular-reference-replacer.l1.spec.ts
@@ -1,4 +1,6 @@
+import { describe, it, expect } from 'vitest'
 import { createCircularReferenceReplacer } from './circular-reference-replacer'
+import type { ReplacerFunction } from './types'
 
 describe('circularReferenceReplacer', () => {
   it('should replace recursive values', () => {
@@ -13,6 +15,7 @@ describe('circularReferenceReplacer', () => {
       JSON.stringify({ foo }, createCircularReferenceReplacer())
 
     expect(serialize).not.toThrow()
+
     const message = serialize()
 
     expect(JSON.parse(message)).toMatchObject({
@@ -25,7 +28,7 @@ describe('circularReferenceReplacer', () => {
   })
 
   it('should call scoped replacer functions', () => {
-    const spy = vi.fn()
+    const spy = vi.fn<ReplacerFunction>()
     const replacer = createCircularReferenceReplacer(spy)
 
     JSON.stringify({ foo: 'bar' }, replacer)

--- a/packages/ts-helpers/src/serde/error-replacer.l1.spec.ts
+++ b/packages/ts-helpers/src/serde/error-replacer.l1.spec.ts
@@ -1,6 +1,8 @@
+import { describe, it, expect } from 'vitest'
 import { createErrorReplacer } from './error-replacer'
+import type { ReplacerFunction } from './types'
 
-describe('createErrorReplacer', () => {
+describe(createErrorReplacer, () => {
   it('should include name, message, stack and cause in stringified errors', () => {
     const error = new Error('foo', { cause: 'bar' })
 
@@ -15,7 +17,7 @@ describe('createErrorReplacer', () => {
   })
 
   it('should call scoped replacer functions', () => {
-    const spy = vi.fn()
+    const spy = vi.fn<ReplacerFunction>()
     const replacer = createErrorReplacer(spy)
 
     JSON.stringify(new Error('foo'), replacer)

--- a/packages/ts-helpers/src/strings/kebab-case.l1.spec.ts
+++ b/packages/ts-helpers/src/strings/kebab-case.l1.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest'
 import { kebabCaseForShortStrings } from './kebab-case'
 
 describe('kebab-case', () => {

--- a/packages/ts-helpers/tsconfig.lib.json
+++ b/packages/ts-helpers/tsconfig.lib.json
@@ -1,5 +1,5 @@
 {
   "include": ["src/**/*.ts", "@types"],
-  "exclude": ["src/**/*.spec.ts", "**/__mocks__/**/*"],
+  "exclude": ["src/**/*.spec.ts", "**/__mocks__/**/*", "**/*.spec-d.ts"],
   "extends": "@desselbane/configs/tsconfig.neutral.tpl.json"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       '@eslint/js':
         specifier: 9.31.0
         version: 9.31.0
+      '@vitest/eslint-plugin':
+        specifier: 1.3.4
+        version: 1.3.4(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)(vitest@3.2.4(@types/node@24.0.14)(jiti@2.4.2)(yaml@2.8.0))
       '@vue/eslint-config-typescript':
         specifier: 14.6.0
         version: 14.6.0(eslint-plugin-vue@10.3.0(@typescript-eslint/parser@8.37.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.31.0(jiti@2.4.2))(vue-eslint-parser@10.2.0(eslint@9.31.0(jiti@2.4.2))))(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)
@@ -1078,6 +1081,18 @@ packages:
       vitest: 3.2.4
     peerDependenciesMeta:
       '@vitest/browser':
+        optional: true
+
+  '@vitest/eslint-plugin@1.3.4':
+    resolution: {integrity: sha512-EOg8d0jn3BAiKnR55WkFxmxfWA3nmzrbIIuOXyTe6A72duryNgyU+bdBEauA97Aab3ho9kLmAwgPX63Ckj4QEg==}
+    peerDependencies:
+      eslint: '>= 8.57.0'
+      typescript: '>= 5.0.0'
+      vitest: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      vitest:
         optional: true
 
   '@vitest/expect@3.2.4':
@@ -4285,6 +4300,16 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
+      vitest: 3.2.4(@types/node@24.0.14)(jiti@2.4.2)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/eslint-plugin@1.3.4(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)(vitest@3.2.4(@types/node@24.0.14)(jiti@2.4.2)(yaml@2.8.0))':
+    dependencies:
+      '@typescript-eslint/utils': 8.37.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)
+      eslint: 9.31.0(jiti@2.4.2)
+    optionalDependencies:
+      typescript: 5.8.3
       vitest: 3.2.4(@types/node@24.0.14)(jiti@2.4.2)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color

--- a/turbo.json
+++ b/turbo.json
@@ -38,21 +38,21 @@
       "cache": false
     },
     "lint": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "@desselbane/configs#build"],
       "cache": true
     },
     "lint:fix": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "@desselbane/configs#build"],
       "cache": true
     },
     "typecheck:app": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build", "@desselbane/configs#build"]
     },
     "typecheck:lib": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build", "@desselbane/configs#build"]
     },
     "typecheck:vitest": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build", "@desselbane/configs#build"]
     },
     "docs:dev": {
       "cache": false


### PR DESCRIPTION
### Description

- Add `@vitest/eslint-plugin` to ESLint configs for Vitest test file linting
- Support `.spec-d.ts` type test files with updated tsconfig and Vitest config
- Enforce errors on unused inline ESLint configs and disable directives
- Ensure zero ESLint warnings by updating lint scripts and lint-staged configs
- Build `@desselbane/configs` package before linting and type checking tasks
- Fix various linting issues for improved code quality