### PR TITLE
✨ setup: update defaults and fix WingetId for programs

### DIFF
--- a/.changeset/little-trees-wish.md
+++ b/.changeset/little-trees-wish.md
@@ -1,0 +1,5 @@
+---
+"@desselbane/setup": minor
+---
+
+Do not install Elgato StreamDeck software by default.

--- a/.changeset/nasty-forks-attend.md
+++ b/.changeset/nasty-forks-attend.md
@@ -1,0 +1,5 @@
+---
+"@desselbane/setup": minor
+---
+
+Add `Loupedeck` as default installed program

--- a/.changeset/sour-flies-sneeze.md
+++ b/.changeset/sour-flies-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@desselbane/setup": minor
+---
+
+Update `WingetId` of `Region to Share` to be `TomEnglert.RegionToShare`

--- a/packages/setup/src/program.config.json
+++ b/packages/setup/src/program.config.json
@@ -97,7 +97,7 @@
   },
   {
     "Name": "Region to Share",
-    "WingetId": "9N4066W2R5Q4",
+    "WingetId": "TomEnglert.RegionToShare",
     "installDefault": true,
     "group": "Programming"
   },
@@ -218,6 +218,12 @@
   {
     "Name": "Elgato StreamDeck",
     "WingetId": "Elgato.StreamDeck",
+    "installDefault": false,
+    "group": "Peripherals"
+  },
+  {
+    "Name": "Loupedeck",
+    "WingetId": "Loupedeck.Loupedeck",
     "installDefault": true,
     "group": "Peripherals"
   },


### PR DESCRIPTION
Update WingetId of "Region to Share" to correct value for accurate
installation. Add Loupedeck as a default installed program to improve
user setup experience. Disable default installation of Elgato
StreamDeck software to avoid unnecessary installs.