### PR TITLE
✨ feat: add VS Code extensions installer and update prompts

### DIFF
--- a/.changeset/every-ducks-obey.md
+++ b/.changeset/every-ducks-obey.md
@@ -1,0 +1,5 @@
+---
+"@desselbane/setup": major
+---
+
+Initial Release

--- a/.changeset/late-mirrors-smoke.md
+++ b/.changeset/late-mirrors-smoke.md
@@ -1,0 +1,5 @@
+---
+"@desselbane/setup": minor
+---
+
+Add support for installing VS Code extensions

--- a/.changeset/whole-beans-thank.md
+++ b/.changeset/whole-beans-thank.md
@@ -1,0 +1,5 @@
+---
+"@desselbane/setup": patch
+---
+
+Make all top level confirm prompts default to false. This way a user does not install anything by accident.

--- a/packages/setup/README.md
+++ b/packages/setup/README.md
@@ -1,5 +1,9 @@
 # Setup
 
+Manual Steps:
+
+- Install [FiraCode Font](https://github.com/tonsky/FiraCode/wiki/Installing)
+
 Run in Admin Powershell:
 
 ```powershell
@@ -17,4 +21,7 @@ volta install pnpm
 
 pnpm dlx @desselbane/setup -y
 ```
-pnpm dlx @desselbane/setup@rc -y
+
+After the script you might want to
+
+- Restore PowerToys Settings

--- a/packages/setup/src/dsc.ts
+++ b/packages/setup/src/dsc.ts
@@ -13,7 +13,7 @@ export async function runDeveloperDSC() {
   const shouldRunPrompt = await safeTryAsync(
     confirm({
       message: 'Run Developer DSC module?',
-      default: true,
+      default: false,
     }),
   )
   cleanExit(shouldRunPrompt)

--- a/packages/setup/src/install-programs.ts
+++ b/packages/setup/src/install-programs.ts
@@ -19,7 +19,7 @@ export async function installPrograms() {
   const updateInstalledProgramsPrompt = await safeTryAsync(
     confirm({
       message: 'Do you want to update all currently installed Programs?',
-      default: true,
+      default: false,
     }),
   )
   cleanExit(updateInstalledProgramsPrompt)
@@ -31,7 +31,7 @@ export async function installPrograms() {
   const installProgramsPrompt = await safeTryAsync(
     confirm({
       message: 'Do you want to install additional programs?',
-      default: true,
+      default: false,
     }),
   )
   cleanExit(installProgramsPrompt)

--- a/packages/setup/src/install-vscode-extensions.ts
+++ b/packages/setup/src/install-vscode-extensions.ts
@@ -1,0 +1,47 @@
+import path from 'node:path'
+import { existsSync, readFileSync } from 'node:fs'
+import { assertNotNil, safeTry, safeTryAsync } from '@desselbane/ts-helpers'
+import { confirm } from '@inquirer/prompts'
+import { cleanExit, execSync } from './helper'
+
+assertNotNil(process.env.USERPROFILE)
+
+const extensionsPath = path.resolve(
+  path.join(process.env.USERPROFILE, '.config', 'vscode-extensions.txt'),
+)
+
+export async function installVSCodeExtensions() {
+  const shouldInstallPrompt = await safeTryAsync(
+    confirm({
+      message: 'Do you want to install all VS Code extensions?',
+      default: false,
+    }),
+  )
+  cleanExit(shouldInstallPrompt)
+  if (!shouldInstallPrompt.data) {
+    return
+  }
+
+  if (!existsSync(extensionsPath)) {
+    console.error(
+      `Could not find extensions file at ${extensionsPath}. Is the dot config repo set up?`,
+    )
+    process.exit(1)
+  }
+
+  const extensions = readFileSync(extensionsPath).toString().split('\n')
+
+  console.log(
+    `The following extensions will be installed: \n${extensions.join('\n')}`,
+  )
+
+  for (const item of extensions) {
+    const { error } = safeTry(() => {
+      execSync(`code --install-extension ${item}`)
+    })
+
+    if (error != undefined) {
+      console.error(`Failed to install ${item}`)
+    }
+  }
+}

--- a/packages/setup/src/main.ts
+++ b/packages/setup/src/main.ts
@@ -4,6 +4,7 @@ import { execSync, isAdmin } from './helper'
 import { setupDotConfig } from './setup-dot-config'
 import { installPrograms } from './install-programs'
 import { runDeveloperDSC } from './dsc'
+import { installVSCodeExtensions } from './install-vscode-extensions'
 
 console.log('🧙 Checking admin 🧙‍♂️')
 
@@ -17,4 +18,5 @@ console.log('Bootstraping Windows, hold on to your socks')
 
 await setupDotConfig()
 await installPrograms()
+await installVSCodeExtensions()
 await runDeveloperDSC()


### PR DESCRIPTION
- Add installVSCodeExtensions function to install extensions from a
  user config file, prompting before installation.
- Change all top-level confirm prompts to default to false to prevent
  accidental installs.
- Update main setup flow to include VS Code extensions installation.
- Update README with manual steps and usage notes.